### PR TITLE
fix: add missing trailing slash to Kook app URL

### DIFF
--- a/docs/store/categories.js
+++ b/docs/store/categories.js
@@ -1446,7 +1446,7 @@ export const categories = [
         icon: "icons/wrappers/kook.webp",
         url2: "/wrappers/kook",
         apptype2: "wrapper",
-        url: "https://www.kookapp.cn/app"
+        url: "https://www.kookapp.cn/app/"
       },
       {
         name: "Tencent Meeting (腾讯会议)",


### PR DESCRIPTION
This PR fixes a missing trailing slash in the Kook app URL.
No functional changes are introduced.